### PR TITLE
Update haystack-experimental to 0.19.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,28 +1,30 @@
 {% set name = "haystack-experimental" %}
-{% set version = "0.2.0" %}
+{% set version = "0.19.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/haystack_experimental-{{ version }}.tar.gz
-  sha256: 393c543f29c50ea21365f5d032cd8b6bca10256016a3791546f1acc7ac623b07
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/haystack_experimental-{{ version }}.tar.gz
+  sha256: 194f9074f9184a20d2f4efa7b5082dd33118bc886f87937d13e33616cd549067
 
 build:
-  noarch: python
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - hatchling >=1.8.0
     - hatch-vcs
     - pip
   run:
-    - python >=3.8
-    - haystack-ai
+    - python
+    # Upstream has no version pin, but we pin to ensure compatibility
+    # https://github.com/deepset-ai/haystack-experimental/blob/main/pyproject.toml#L17
+    - haystack-ai >=2.25.0
 
 test:
   imports:
@@ -35,8 +37,15 @@ test:
 about:
   home: https://github.com/deepset-ai/haystack-experimental
   summary: Experimental components and features for the Haystack LLM framework.
+  description: |
+    Provides experimental components and features for the Haystack LLM framework.
+    These are early-access features with a 3-month lifespan before promotion to
+    haystack-ai core or removal.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  doc_url: https://docs.haystack.deepset.ai/docs/intro
+  dev_url: https://github.com/deepset-ai/haystack-experimental
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
haystack-experimental 0.19.0

**Destination channel:** defaults

### Links

- [PKG-13009](https://anaconda.atlassian.net/browse/PKG-13009)
- [PKG-6406](https://anaconda.atlassian.net/browse/PKG-6406) (parent: haystack.ai latest)
- [Upstream repository](https://github.com/deepset-ai/haystack-experimental)
- [Upstream changelog/diff](https://github.com/deepset-ai/haystack-experimental/compare/v0.2.0...v0.19.0)
- Relevant dependency PRs:
  - [lazy-imports 1.2.0](https://github.com/AnacondaRecipes/lazy-imports-feedstock/pull/2) ✅ merged & released
  - [haystack-ai 2.25.2](https://github.com/AnacondaRecipes/haystack-ai-feedstock/pull/2) ✅ merged & released

### Explanation of changes:

- Version bump from 0.2.0 to 0.19.0
- Update Python requirement to >=3.10
- Pin `haystack-ai >=2.25.0` (upstream has no version pin per [pyproject.toml](https://github.com/deepset-ai/haystack-experimental/blob/main/pyproject.toml#L17), but we pin conservatively for compatibility)
- This is Round 3/3 of the haystack.ai ecosystem (PKG-6406)

[PKG-13009]: https://anaconda.atlassian.net/browse/PKG-13009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-6406]: https://anaconda.atlassian.net/browse/PKG-6406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ